### PR TITLE
Removes the "Modal Header" and "A bunch of text" that appears in the …

### DIFF
--- a/js/components/addresssave.js
+++ b/js/components/addresssave.js
@@ -83,8 +83,6 @@ function writeAddresses() {
 
                         <div id="nearby-${index}" class="modal bottom-sheet">
                           <div class="modal-content nearby">
-                            <h4>Modal Header</h4>
-                            <p>A bunch of text</p>
                           </div>
                         </div>
 


### PR DESCRIPTION
…bottom "nearby things" modal, when first opened (before the JS clears it and overwrites it).