### PR TITLE
Remove pins when an address is deleted

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   </header>
   <section id="top-panel" class="row">
     <div class="col s8">
-      <div id="map" style="height:600px;"></div>
+      <div id="map" style="height:600px"></div>
     </div>
     <div class="col s4">
       <div class="row">

--- a/js/components/addresssave.js
+++ b/js/components/addresssave.js
@@ -181,7 +181,10 @@ function storeAddress(object, placelabel, isHome) {
 function deleteAddress(index) {
     mapManager.addresses.splice(index, 1);
     database.ref().set({"addresses": JSON.stringify(mapManager.addresses)});
-
+    mapManager
+        .clearPins()
+        .setPins()
+        .displayPins(mapManager.map);
 }
 
 // function testStorage() {


### PR DESCRIPTION
This ensures a pin is deleted when an address is deleted. It also creates a new error from Materialize.js:

```
Uncaught TypeError: Cannot read property 'M_Modal' of null
```

I believe this may be due to Materialize closing the collapsible body for the deleted address, and seems harmless.